### PR TITLE
Update index.js

### DIFF
--- a/frontend_sanity/src/index.js
+++ b/frontend_sanity/src/index.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import App from './App';
 import './index.css';
 
-ReactDOM.render(
-  <Router>
-    <App />
-  </Router>,
-  document.getElementById('root'),
-);
+const root = ReactDOM.createRoot(document.getElementById("root"))
 
+root.render(
+<Router>
+<App />
+</Router>
+);


### PR DESCRIPTION
ReactDOM.render is no longer supported in React 18. Use createRoot instead [duplicate]. 